### PR TITLE
bug fix  of dpdk

### DIFF
--- a/drivers/net/i40e/i40e_ethdev.c
+++ b/drivers/net/i40e/i40e_ethdev.c
@@ -1121,10 +1121,7 @@ eth_i40e_dev_init(struct rte_eth_dev *dev)
 
 	/* Initialize the parameters for adminq */
 	i40e_init_adminq_parameter(hw);
-	/* RSK debugging -- this function seems to fail */
-	PMD_INIT_LOG(ERR, "Dbg: adminq ");
 	ret = i40e_init_adminq(hw);
-	PMD_INIT_LOG(ERR, "adminq\n");
 	if (ret != I40E_SUCCESS) {
 		PMD_INIT_LOG(ERR, "Failed to init adminq: %d", ret);
 		return -EIO;

--- a/lib/librte_eal/common/eal_common_memzone.c
+++ b/lib/librte_eal/common/eal_common_memzone.c
@@ -53,6 +53,7 @@
 #include "malloc_heap.h"
 #include "malloc_elem.h"
 #include "eal_private.h"
+#include "cos_eal_pci.h"
 
 /* RSK */
 #define SIMPLE_MZ 1
@@ -509,8 +510,7 @@ simple_memzone_create(const char *name, size_t size) {
 
 	snprintf(mz->name, sizeof(mz->name), "%s", name);
 	/* mz->phys_addr = rte_malloc_virt2phy(mz_addr); */
-	/* Hope that this doesn't break! */
-	mz->phys_addr = 0;
+	mz->phys_addr = (phys_addr_t)(uintptr_t)cos_map_virt_to_phys(mz_addr);
 	mz->addr = mz_addr;
 	mz->len = size;
 	mz->hugepage_sz = 0;

--- a/lib/librte_eal/common/include/arch/x86/rte_memcpy.h
+++ b/lib/librte_eal/common/include/arch/x86/rte_memcpy.h
@@ -891,6 +891,7 @@ rte_memcpy_aligned(void *dst, const void *src, size_t n)
 static inline void *
 rte_memcpy(void *dst, const void *src, size_t n)
 {
+  return memcpy(dst, src, n);
 	if (!(((uintptr_t)dst | (uintptr_t)src) & ALIGNMENT_MASK))
 		return rte_memcpy_aligned(dst, src, n);
 	else

--- a/lib/librte_eal/common/rte_malloc.c
+++ b/lib/librte_eal/common/rte_malloc.c
@@ -58,6 +58,7 @@
 void rte_free(void *addr)
 {
 	if (addr == NULL) return;
+	return free(addr);
 	if (malloc_elem_free(malloc_elem_from_data(addr)) < 0)
 		rte_panic("Fatal error: Invalid memory\n");
 }
@@ -74,7 +75,9 @@ rte_malloc_socket(const char *type, size_t size, unsigned align, int socket_arg)
 
 	/* RSK: simplified rte_malloc until we decide to plug in hugepages */
 	if (size == 0) return NULL;
-	return malloc(size);
+	ret = malloc(size);
+	if (ret) memset(ret, 0, size);
+	return ret;
 
 	/* return NULL if size is 0 or alignment is not power-of-2 */
 	if (size == 0 || (align && !rte_is_power_of_2(align)))


### PR DESCRIPTION
 - correctly set up physical address of memzone
 - replace SSE based ret_memcpy to normal musl memcpy
 - change rte_free to use musl free
 - zero out malloced memory